### PR TITLE
Add integration spec and fix n+1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'rspec-rails'
   gem 'shoulda-matchers'
+  gem 'webdrivers'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -46,12 +46,10 @@ gem 'bootsnap', require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem 'capybara'
+
   gem 'debug', platforms: %i[mri mswin mswin64 mingw x64_mingw]
   gem 'factory_bot_rails'
-  gem 'rails-controller-testing'
   gem 'rspec-rails'
-  gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'webdrivers'
 end
@@ -69,8 +67,12 @@ end
 
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
+  gem 'capybara'
   gem 'database_cleaner'
   gem 'poltergeist'
+  gem 'selenium-webdriver'
+
+  gem 'rails-controller-testing'
 end
 
 gem 'rubocop', '>= 1.0', '< 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -46,9 +46,12 @@ gem 'bootsnap', require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+  gem 'capybara'
   gem 'debug', platforms: %i[mri mswin mswin64 mingw x64_mingw]
   gem 'factory_bot_rails'
+  gem 'rails-controller-testing'
   gem 'rspec-rails'
+  gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'webdrivers'
 end
@@ -66,8 +69,8 @@ end
 
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-  gem 'capybara'
-  gem 'selenium-webdriver'
+  gem 'database_cleaner'
+  gem 'poltergeist'
 end
 
 gem 'rubocop', '>= 1.0', '< 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     webrick (1.8.1)
     websocket (1.2.10)
     websocket-driver (0.7.6)
@@ -304,6 +308,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webdrivers
 
 RUBY VERSION
    ruby 3.0.6p216

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,9 +92,16 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cliver (0.3.2)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
+    database_cleaner (2.0.2)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.1.0)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date (3.3.3)
     debug (1.8.0)
       irb (>= 1.5.0)
@@ -157,6 +164,10 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    poltergeist (1.18.1)
+      capybara (>= 2.1, < 4)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     psych (5.1.1.1)
       stringio
     public_suffix (5.0.3)
@@ -185,6 +196,10 @@ GEM
       activesupport (= 7.1.1)
       bundler (>= 1.15.0)
       railties (= 7.1.1)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -292,13 +307,16 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
+  database_cleaner
   debug
   factory_bot_rails
   importmap-rails
   jbuilder
   pg (~> 1.1)
+  poltergeist
   puma (>= 5.0)
   rails (~> 7.1.1)
+  rails-controller-testing
   rspec-rails
   rubocop (>= 1.0, < 2.0)
   selenium-webdriver

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="center">
 
   <h2><b>Blog</b></h2>
-  <h4>Ivan Gonzalez</h4>
+  <h4>Ivan Gonzalez & Javier Aybar</h4>
 
 </div>
 
@@ -53,6 +53,7 @@
 - **Add Devise.**
 - **Add authorization rules.**
 - **Add API endpoints.**
+- **Add unit rspec and integration Capybara tests.**
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -112,6 +113,10 @@ To run tests, run the following command:
 - Twitter: [@Ivan Gonzalez](https://twitter.com/ivang2204)
 - LinkedIn: [Iván Gonzalez Robles](https://www.linkedin.com/in/iván-gonzalez-robles-957491275/)
 
+👤 **Javier Aybar**
+
+- GitHub: [@JavierAybar](https://github.com/JavierAybar)
+- LinkedIn: [@JavierAybar](https://www.linkedin.com/in/javier-aybar-932376274/)
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/app/assets/stylesheets/users_show.css
+++ b/app/assets/stylesheets/users_show.css
@@ -110,7 +110,7 @@ img {
   color: #000;
 }
 
-a {
+.post-item-container a {
   text-decoration: none;
   color: #000;
   font-weight: bold;

--- a/app/assets/stylesheets/users_show.css
+++ b/app/assets/stylesheets/users_show.css
@@ -109,3 +109,9 @@ img {
   text-decoration: none;
   color: #000;
 }
+
+a {
+  text-decoration: none;
+  color: #000;
+  font-weight: bold;
+}

--- a/app/assets/stylesheets/users_show.css
+++ b/app/assets/stylesheets/users_show.css
@@ -115,3 +115,9 @@ a {
   color: #000;
   font-weight: bold;
 }
+
+.post-btn-all button {
+  border: none;
+  background-color: #fff;
+  cursor: pointer;
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
-    @posts = @user.posts
+    @posts = @user.posts.includes(:comments, :likes)
   end
 
   def show

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   def index
-    @user = User.includes(:posts).find(params[:user_id])
+    @user = User.find(params[:user_id])
     @posts = @user.posts.includes(:comments, :likes)
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,12 +1,12 @@
 class PostsController < ApplicationController
   def index
-    @user = User.find(params[:user_id])
+    @user = User.includes(:posts).find(params[:user_id])
     @posts = @user.posts.includes(:comments, :likes)
   end
 
   def show
+    @user = User.includes(:posts).find(params[:user_id])
     @post = Post.find(params[:id])
-    @user = User.find(params[:user_id])
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,9 @@
 class UsersController < ApplicationController
   def index
-    @users = User.all
+    @users = User.includes(:posts).all
   end
 
   def show
-    @user = User.find(params[:id])
+    @user = User.includes(:posts).find(params[:id])
   end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -6,7 +6,7 @@
     <div class="posts-mainContainer">
       <div class="postUser-header">
         <div class="postUser-image">
-          <img @user.photo alt="User Image">
+          <%= image_tag @user.photo, alt: "User photo", class: 'user-photo' %>
         </div>
         <div class="userShow-details">
           <span id="userName"><%= @user.name %></span>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -42,6 +42,11 @@
             </div>
           </div>
         <% end %>
+        <div class="post-btn-container">
+          <div class="post-btn-all">
+            <%= button_to "Pagination" %>
+          </div>
+        </div>
       </div> 
     </div>
   </body>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -19,7 +19,7 @@
         <% @post.comments.each do |comment| %>
           <div class="postComments">
             <span><%= comment.user.name %>:</span>
-            <span><%= comment.text %></span>
+            <span class="comment-text"><%= comment.text %></span>
           </div>
         <% end %>
       </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -8,7 +8,7 @@
         <% @users.each do |user| %>
           <div class="user-item">
             <div class="user-image">
-              <%= image_tag user.photo, alt: "User photo" %>
+              <%= image_tag user.photo, alt: "User photo", class: 'user-photo' %>
             </div>
             <div class="user-details">
               <span id="userName"><%= link_to user.name, user %></span>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,7 +22,7 @@
       <div class="user-posts-container">
         <% @user.three_most_recent_post.each do |post| %>
           <div class="post-item-container">
-            <span class="post-title"><%= post.title %></span>
+            <%= link_to post.title, user_post_path(@user, post), class: "post-title" %>
             <p class="post-text"><%= post.text %></p>
             <div class="post-details">
               <div class="post-show-action">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,7 +6,7 @@
     <div class="usersShow-container">
       <div class="userShow-header">
         <div class="userShow-image">
-          <%= image_tag @user.photo, alt: "User photo" %>
+          <%= image_tag @user.photo, alt: "User photo", class: 'user-photo' %>
         </div>
         <div class="userShow-details">
           <span id="userName"><%= @user.name %></span>

--- a/spec/features/posts_index_spec.rb
+++ b/spec/features/posts_index_spec.rb
@@ -53,4 +53,14 @@ RSpec.describe 'User Posts Index Page', type: feature do
     expect(page).to have_content('Comment Text 2')
     expect(page).to have_content('Comment Text 1')
   end
+
+  it 'displays how many comments a post has' do
+    post= Post.create(title: 'Post Title', text: 'Post Text', user: user)
+    comment1 = Comment.create(text: 'Comment Text 1', post: post, user: user)
+    comment2 = Comment.create(text: 'Comment Text 2', post: post, user: user)
+    Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
+    page = Capybara.page
+
+    expect(page).to have_content('Comments: 2')
+  end
 end

--- a/spec/features/posts_index_spec.rb
+++ b/spec/features/posts_index_spec.rb
@@ -34,4 +34,12 @@ RSpec.describe 'User Posts Index Page', type: feature do
 
     expect(page).to have_content('Post Title')
   end
+
+  it 'displays some of the post body' do
+    post= Post.create(title: 'Post Title', text: 'Post Text', user: user)
+    Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
+    page = Capybara.page
+
+    expect(page).to have_content('Post Text')
+  end
 end

--- a/spec/features/posts_index_spec.rb
+++ b/spec/features/posts_index_spec.rb
@@ -1,25 +1,26 @@
 require 'rails_helper'
+require 'capybara/rails'
 
 RSpec.describe 'User Posts Index Page', type: feature do
   let(:user) { User.create(name: 'Username1', bio: 'User Bio', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg') }
-  
+
   it 'displays the correct user profile picture' do
     Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
     page = Capybara.page
-    
+
     expect(page).to have_css("img[src*='#{user.photo}']")
   end
 
   it 'displays the correct user name and profile image' do
     Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
     page = Capybara.page
-    
+
     expect(page).to have_content('Username1')
   end
 
   it 'displays the number of posts the user has written' do
-    post1 = Post.create(title: 'Post Title 1', text: 'Post Text 1', user: user)
-    post2 = Post.create(title: 'Post Title 2', text: 'Post Text 2', user: user)
+    Post.create(title: 'Post Title 1', text: 'Post Text 1', user: user)
+    Post.create(title: 'Post Title 2', text: 'Post Text 2', user: user)
 
     Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
     page = Capybara.page
@@ -28,7 +29,7 @@ RSpec.describe 'User Posts Index Page', type: feature do
   end
 
   it 'displays a post title' do
-    post = Post.create(title: 'Post Title', text: 'Post Text', user: user)
+    Post.create(title: 'Post Title', text: 'Post Text', user: user)
     Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
     page = Capybara.page
 
@@ -36,7 +37,7 @@ RSpec.describe 'User Posts Index Page', type: feature do
   end
 
   it 'displays some of the post body' do
-    post = Post.create(title: 'Post Title', text: 'Post Text', user: user)
+    Post.create(title: 'Post Title', text: 'Post Text', user: user)
     Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
     page = Capybara.page
 
@@ -45,8 +46,8 @@ RSpec.describe 'User Posts Index Page', type: feature do
 
   it 'displays the first comments on a post' do
     post = Post.create(title: 'Post Title', text: 'Post Text', user: user)
-    comment1 = Comment.create(text: 'Comment Text 1', post: post, user: user)
-    comment2 = Comment.create(text: 'Comment Text 2', post: post, user: user)
+    Comment.create(text: 'Comment Text 1', post: post, user: user)
+    Comment.create(text: 'Comment Text 2', post: post, user: user)
     Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
     page = Capybara.page
 
@@ -56,8 +57,8 @@ RSpec.describe 'User Posts Index Page', type: feature do
 
   it 'displays how many comments a post has' do
     post = Post.create(title: 'Post Title', text: 'Post Text', user: user)
-    comment1 = Comment.create(text: 'Comment Text 1', post: post, user: user)
-    comment2 = Comment.create(text: 'Comment Text 2', post: post, user: user)
+    Comment.create(text: 'Comment Text 1', post: post, user: user)
+    Comment.create(text: 'Comment Text 2', post: post, user: user)
     Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
     page = Capybara.page
 
@@ -66,7 +67,7 @@ RSpec.describe 'User Posts Index Page', type: feature do
 
   it 'displays how many likes a post has' do
     post = Post.create(title: 'Post Title', text: 'Post Text', user: user)
-    like = Like.create(post: post, user: user)
+    Like.create(post: post, user: user)
     Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
     page = Capybara.page
 
@@ -78,5 +79,17 @@ RSpec.describe 'User Posts Index Page', type: feature do
     page = Capybara.page
 
     expect(page).to have_selector('button', text: 'Pagination')
+  end
+
+  it 'redirects to the post show page when a post is clicked' do
+    post = Post.create(title: 'Post Title', text: 'Post Text', user: user)
+    Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
+    page = Capybara.page
+    @post_link = page.find_link('Post Title')
+    @user_post_path = Rails.application.routes.url_helpers.user_post_path(user, post)
+    @post_link.click
+    current_path = Capybara.current_path
+
+    expect(current_path).to eq(@user_post_path)
   end
 end

--- a/spec/features/posts_index_spec.rb
+++ b/spec/features/posts_index_spec.rb
@@ -16,4 +16,14 @@ RSpec.describe 'User Posts Index Page', type: feature do
     
     expect(page).to have_content('Username1')
   end
+
+  it 'displays the number of posts the user has written' do
+    post1 = Post.create(title: 'Post Title 1', text: 'Post Text 1', user: user)
+    post2 = Post.create(title: 'Post Title 2', text: 'Post Text 2', user: user)
+
+    Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
+    page = Capybara.page
+
+    expect(page).to have_content('Number of posts: 2')
+  end
 end

--- a/spec/features/posts_index_spec.rb
+++ b/spec/features/posts_index_spec.rb
@@ -72,4 +72,11 @@ RSpec.describe 'User Posts Index Page', type: feature do
 
     expect(page).to have_content('Likes: 1')
   end
+
+  it 'displays a button for pagination to see more posts' do
+    Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
+    page = Capybara.page
+
+    expect(page).to have_selector('button', text: 'Pagination')
+  end
 end

--- a/spec/features/posts_index_spec.rb
+++ b/spec/features/posts_index_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'User Posts Index Page', type: feature do
+  let(:user) { User.create(name: 'Username1', bio: 'User Bio', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg') }
+  
+  it 'displays the correct user profile picture' do
+    Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
+    page = Capybara.page
+    
+    expect(page).to have_css("img[src*='#{user.photo}']")
+  end
+
+  it 'displays the correct user name and profile image' do
+    Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
+    page = Capybara.page
+    
+    expect(page).to have_content('Username1')
+  end
+end

--- a/spec/features/posts_index_spec.rb
+++ b/spec/features/posts_index_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'User Posts Index Page', type: feature do
   end
 
   it 'displays a post title' do
-    post= Post.create(title: 'Post Title', text: 'Post Text', user: user)
+    post = Post.create(title: 'Post Title', text: 'Post Text', user: user)
     Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
     page = Capybara.page
 
@@ -36,7 +36,7 @@ RSpec.describe 'User Posts Index Page', type: feature do
   end
 
   it 'displays some of the post body' do
-    post= Post.create(title: 'Post Title', text: 'Post Text', user: user)
+    post = Post.create(title: 'Post Title', text: 'Post Text', user: user)
     Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
     page = Capybara.page
 
@@ -44,7 +44,7 @@ RSpec.describe 'User Posts Index Page', type: feature do
   end
 
   it 'displays the first comments on a post' do
-    post= Post.create(title: 'Post Title', text: 'Post Text', user: user)
+    post = Post.create(title: 'Post Title', text: 'Post Text', user: user)
     comment1 = Comment.create(text: 'Comment Text 1', post: post, user: user)
     comment2 = Comment.create(text: 'Comment Text 2', post: post, user: user)
     Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
@@ -55,12 +55,21 @@ RSpec.describe 'User Posts Index Page', type: feature do
   end
 
   it 'displays how many comments a post has' do
-    post= Post.create(title: 'Post Title', text: 'Post Text', user: user)
+    post = Post.create(title: 'Post Title', text: 'Post Text', user: user)
     comment1 = Comment.create(text: 'Comment Text 1', post: post, user: user)
     comment2 = Comment.create(text: 'Comment Text 2', post: post, user: user)
     Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
     page = Capybara.page
 
     expect(page).to have_content('Comments: 2')
+  end
+
+  it 'displays how many likes a post has' do
+    post = Post.create(title: 'Post Title', text: 'Post Text', user: user)
+    like = Like.create(post: post, user: user)
+    Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
+    page = Capybara.page
+
+    expect(page).to have_content('Likes: 1')
   end
 end

--- a/spec/features/posts_index_spec.rb
+++ b/spec/features/posts_index_spec.rb
@@ -26,4 +26,12 @@ RSpec.describe 'User Posts Index Page', type: feature do
 
     expect(page).to have_content('Number of posts: 2')
   end
+
+  it 'displays a post title' do
+    post= Post.create(title: 'Post Title', text: 'Post Text', user: user)
+    Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
+    page = Capybara.page
+
+    expect(page).to have_content('Post Title')
+  end
 end

--- a/spec/features/posts_index_spec.rb
+++ b/spec/features/posts_index_spec.rb
@@ -42,4 +42,15 @@ RSpec.describe 'User Posts Index Page', type: feature do
 
     expect(page).to have_content('Post Text')
   end
+
+  it 'displays the first comments on a post' do
+    post= Post.create(title: 'Post Title', text: 'Post Text', user: user)
+    comment1 = Comment.create(text: 'Comment Text 1', post: post, user: user)
+    comment2 = Comment.create(text: 'Comment Text 2', post: post, user: user)
+    Capybara.visit Rails.application.routes.url_helpers.user_posts_path(user)
+    page = Capybara.page
+
+    expect(page).to have_content('Comment Text 2')
+    expect(page).to have_content('Comment Text 1')
+  end
 end

--- a/spec/features/posts_show_spec.rb
+++ b/spec/features/posts_show_spec.rb
@@ -17,4 +17,13 @@ RSpec.describe 'User Post Show Page', type: feature do
     expect(page).to have_content('Sam')
   end
 
+  it 'displays the number of comments the post has' do
+    Capybara.visit Rails.application.routes.url_helpers.user_post_path(user, post)
+    page = Capybara.page
+    expect(page).to have_content('Comments: 0')
+    Comment.create(text: 'This is a comment for testing', post: post, user: user)
+    Capybara.visit Rails.application.routes.url_helpers.user_post_path(user, post)
+    expect(page).to have_content('Comments: 1')
+  end
+  
 end

--- a/spec/features/posts_show_spec.rb
+++ b/spec/features/posts_show_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+require 'capybara/rails'
+
+RSpec.describe 'User Post Show Page', type: feature do
+  let(:user) { User.create(name: 'Sam', bio: 'User Bio', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg') }
+  let(:post) { Post.create(title: 'Post Title for testing', text: 'Post Text for testing', user: user) }
+
+  it 'displays the post title' do
+    Capybara.visit Rails.application.routes.url_helpers.user_post_path(user, post)
+    page = Capybara.page
+    expect(page).to have_content('Post Title for testing')
+  end
+
+end

--- a/spec/features/posts_show_spec.rb
+++ b/spec/features/posts_show_spec.rb
@@ -53,5 +53,13 @@ RSpec.describe 'User Post Show Page', type: feature do
     expect(page).to have_content('Mike')
   end
 
-  
+  it 'displays the comment each commentor left in the correct place' do
+    third_user = User.create(name: 'Mike', bio: 'Software developer',
+                             photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg')
+    Comment.create(text: 'Comment Text for testing', post: post, user: third_user)
+    Capybara.visit Rails.application.routes.url_helpers.user_post_path(user, post)
+    page = Capybara.page
+    comment_content = page.find('.comment-text')
+    expect(comment_content).to have_content('Comment Text for testing')
+  end
 end

--- a/spec/features/posts_show_spec.rb
+++ b/spec/features/posts_show_spec.rb
@@ -11,4 +11,10 @@ RSpec.describe 'User Post Show Page', type: feature do
     expect(page).to have_content('Post Title for testing')
   end
 
+  it 'displays the name of the user who wrote the post' do
+    Capybara.visit Rails.application.routes.url_helpers.user_post_path(user, post)
+    page = Capybara.page
+    expect(page).to have_content('Sam')
+  end
+
 end

--- a/spec/features/posts_show_spec.rb
+++ b/spec/features/posts_show_spec.rb
@@ -38,4 +38,10 @@ RSpec.describe 'User Post Show Page', type: feature do
     expect(like_counter).to have_content("Likes: #{like_count}")
   end
 
+  it 'displays the post body' do
+    Capybara.visit Rails.application.routes.url_helpers.user_post_path(user, post)
+    page = Capybara.page
+    expect(page).to have_content('Post Text for testing')
+  end
+
 end

--- a/spec/features/posts_show_spec.rb
+++ b/spec/features/posts_show_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'User Post Show Page', type: feature do
     Capybara.visit Rails.application.routes.url_helpers.user_post_path(user, post)
     expect(page).to have_content('Comments: 1')
   end
-  
+
   it 'displays the number of likes the post has' do
     Capybara.visit Rails.application.routes.url_helpers.user_post_path(user, post)
     page = Capybara.page

--- a/spec/features/posts_show_spec.rb
+++ b/spec/features/posts_show_spec.rb
@@ -26,4 +26,16 @@ RSpec.describe 'User Post Show Page', type: feature do
     expect(page).to have_content('Comments: 1')
   end
   
+  it 'displays the number of likes the post has' do
+    Capybara.visit Rails.application.routes.url_helpers.user_post_path(user, post)
+    page = Capybara.page
+    like_counter = page.find('.postUser-comments span:contains("Likes:")')
+    expect(like_counter).to have_content('Likes: 0')
+    # Simulate user interaction by dispatching a like to the post
+    like_counter.click
+    Capybara.visit Rails.application.routes.url_helpers.user_post_path(user, post)
+    like_count = post.likes.count
+    expect(like_counter).to have_content("Likes: #{like_count}")
+  end
+
 end

--- a/spec/features/posts_show_spec.rb
+++ b/spec/features/posts_show_spec.rb
@@ -44,4 +44,14 @@ RSpec.describe 'User Post Show Page', type: feature do
     expect(page).to have_content('Post Text for testing')
   end
 
+  it 'displays the username of each commentor' do
+    second_user = User.create(name: 'Mike', bio: 'Software developer',
+                              photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg')
+    Comment.create(text: 'Comment Text for testing', post: post, user: second_user)
+    Capybara.visit Rails.application.routes.url_helpers.user_post_path(user, post)
+    page = Capybara.page
+    expect(page).to have_content('Mike')
+  end
+
+  
 end

--- a/spec/features/user_index_spec.rb
+++ b/spec/features/user_index_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'Users Index', type: :feature do
+  it 'displays the user name, profile picture, and post count' do
+    User.create(name: 'User test 1',
+                photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg', bio: 'User Bio')
+    visit users_path
+
+    expect(page).to have_content('User test 1')
+    expect(page).to have_selector('img.user-photo[alt="User photo"]')
+    expect(page).to have_content('Number of posts: 0')
+  end
+end

--- a/spec/features/user_index_spec.rb
+++ b/spec/features/user_index_spec.rb
@@ -10,4 +10,18 @@ RSpec.describe 'Users Index', type: :feature do
     expect(page).to have_selector('img.user-photo[alt="User photo"]')
     expect(page).to have_content('Number of posts: 0')
   end
+
+  context 'Click on a user' do
+    it 'redirects to user show page when clicking on a user' do
+      User.create(name: 'Sam',
+                  photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg', bio: 'Science Teacher')
+
+      user2 = User.create(name: 'Joe',
+                          photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg', bio: 'Developer full stack')
+
+      visit users_path
+      click_link user2.name
+      expect(current_path).to eq(user_path(user2))
+    end
+  end
 end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -16,4 +16,13 @@ RSpec.describe 'User Show Page', type: :feature do
 
     expect(page).to have_content('Number of posts: 1')
   end
+
+  it 'displays the username' do
+    user = User.create(name: 'Jim', bio: 'Student', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg')
+    Post.create(title: 'Post title for testing', text: 'Post Text for testing', user: user)
+
+    visit user_path(user)
+
+    expect(page).to have_content('Jim')
+  end
 end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -54,4 +54,12 @@ RSpec.describe 'User Show Page', type: :feature do
     expect(page).to have_content(post2.text)
     expect(page).to have_content(post1.title)
   end
+
+  it 'displays the "See all posts" button' do
+    user = User.create(name: 'Jim', bio: 'Student', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg')
+
+    visit user_path(user)
+
+    expect(page).to have_link('See all posts', href: user_posts_path(user))
+  end
 end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'User Show Page', type: :feature do
+  it 'displays the correct user profile image' do
+    user = User.create(name: 'Tom', bio: 'Gamer', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg')
+    visit user_path(user)
+    expect(page).to have_css("img[src*='#{user.photo}']")
+  end
+end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -3,7 +3,17 @@ require 'rails_helper'
 RSpec.describe 'User Show Page', type: :feature do
   it 'displays the correct user profile image' do
     user = User.create(name: 'Tom', bio: 'Gamer', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg')
+
     visit user_path(user)
     expect(page).to have_css("img[src*='#{user.photo}']")
+  end
+
+  it 'displays the correct number of user posts' do
+    user = User.create(name: 'Jim', bio: 'Student', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg')
+    Post.create(title: 'Post title for testing', text: 'Post Text for testing', user: user)
+
+    visit user_path(user)
+
+    expect(page).to have_content('Number of posts: 1')
   end
 end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -25,4 +25,12 @@ RSpec.describe 'User Show Page', type: :feature do
 
     expect(page).to have_content('Jim')
   end
+
+  it 'displays the correct username' do
+    user = User.create(name: 'Jim', bio: 'Student', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg')
+    Post.create(title: 'Post title for testing', text: 'Post Text for testing', user: user)
+
+    visit user_path(user)
+    expect(page).not_to have_content('incorrect name')
+  end
 end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -41,4 +41,17 @@ RSpec.describe 'User Show Page', type: :feature do
     visit user_path(user)
     expect(page).to have_content('Student')
   end
+
+  it 'displays the three most recent user posts' do
+    user = User.create(name: 'Kobe', bio: 'Basketball player', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg')
+    post1 = Post.create(title: 'Post Title 1', text: 'Post Text 1', user: user)
+    post2 = Post.create(title: 'Post Title 2', text: 'Post Text 2', user: user)
+    post3 = Post.create(title: 'Post Title 3', text: 'Post Text 3', user: user)
+
+    visit user_path(user)
+
+    expect(page).to have_content(post3.title)
+    expect(page).to have_content(post2.text)
+    expect(page).to have_content(post1.title)
+  end
 end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -62,4 +62,14 @@ RSpec.describe 'User Show Page', type: :feature do
 
     expect(page).to have_link('See all posts', href: user_posts_path(user))
   end
+
+  it 'redirects to the see all users posts page' do
+    user = user = User.create(name: 'Ben', bio: 'Actor', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg')
+
+    visit user_path(user)
+
+    click_link('See all posts')
+
+    expect(current_path).to eq(user_posts_path(user))
+  end
 end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -33,4 +33,12 @@ RSpec.describe 'User Show Page', type: :feature do
     visit user_path(user)
     expect(page).not_to have_content('incorrect name')
   end
+
+  it 'displays the correct user bio' do
+    user = User.create(name: 'Jim', bio: 'Student', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg')
+    Post.create(title: 'Post title for testing', text: 'Post Text for testing', user: user)
+
+    visit user_path(user)
+    expect(page).to have_content('Student')
+  end
 end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -64,12 +64,23 @@ RSpec.describe 'User Show Page', type: :feature do
   end
 
   it 'redirects to the see all users posts page' do
-    user = user = User.create(name: 'Ben', bio: 'Actor', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg')
+    user = User.create(name: 'Ben', bio: 'Actor', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg')
 
     visit user_path(user)
 
     click_link('See all posts')
 
     expect(current_path).to eq(user_posts_path(user))
+  end
+
+  it 'redirects to the post show page when clicking a user post' do
+    user = User.create(name: 'Mat', bio: 'Front end developer', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg')
+    post = Post.create(title: 'Post title for testing', text: 'Post text for testing', user: user)
+
+    visit user_path(user)
+
+    click_link(post.title)
+
+    expect(current_path).to eq(user_post_path(user, post))
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Comment, type: :model do
   describe '#update_comments_counter' do
     it 'updates comments_counter when a comment is saved' do
       user = User.create(name: 'Jim')
-      post = Post.create(user: user, title: 'Test Post', comments_counter: 0, likes_counter: 0)
+      post = Post.create(user: user, title: 'Test Post', text: 'Post text for testing', comments_counter: 0,
+                         likes_counter: 0)
 
       comment = Comment.new(text: 'Comment for test', post: post, user: user)
       expect do

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe Like, type: :model do
   it 'is valid with a post_id' do
     user = User.create(name: 'Jim', posts_counter: 0)
-    post = Post.create(user: user, title: 'Post for testing', comments_counter: 0, likes_counter: 0)
+    post = Post.create(user: user, title: 'Post for testing', text: 'Post text for testing', comments_counter: 0,
+                       likes_counter: 0)
     like = Like.new(post: post, user: user)
     expect(like).to be_valid
   end
@@ -11,7 +12,8 @@ RSpec.describe Like, type: :model do
   describe '#update_comments_counter' do
     it 'updates the likes_counter when a like is created' do
       user = User.create(name: 'Jim', posts_counter: 0)
-      post = Post.create(user: user, title: 'Test Post', comments_counter: 0, likes_counter: 0)
+      post = Post.create(user: user, title: 'Test Post', text: 'Post text for testing', comments_counter: 0,
+                         likes_counter: 0)
 
       like = Like.new(post: post, user: user)
       like.save

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe Post, type: :model do
   it 'is valid with a title, with comments_counter and likes_counter greater than or equal to zero' do
     user = User.create(name: 'Sam', posts_counter: 0)
-    post = Post.new(user: user, title: 'Post for testing', comments_counter: 0, likes_counter: 0)
+    post = Post.new(user: user, title: 'Post for testing', text: 'Post text for testing', comments_counter: 0,
+                    likes_counter: 0)
     expect(post).to be_valid
   end
 
@@ -46,7 +47,8 @@ RSpec.describe Post, type: :model do
   describe '#update_user_post_counter' do
     it 'increments the user posts_counter when a post is saved' do
       user = User.create(name: 'Ted', posts_counter: 0)
-      post = Post.new(user: user, title: 'Test Post', comments_counter: 0, likes_counter: 0)
+      post = Post.new(user: user, title: 'Test Post', text: 'Post text for testing', comments_counter: 0,
+                      likes_counter: 0)
 
       expect do
         post.save

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,10 @@ require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require 'capybara/poltergeist'
+require 'capybara/rspec'
+Capybara.javascript_driver = :poltergeist
+Capybara.server = :puma
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -36,7 +40,26 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
 
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'rspec/rails'
 require 'capybara/poltergeist'
 require 'capybara/rspec'
+require 'capybara/rails'
 Capybara.javascript_driver = :poltergeist
 Capybara.server = :puma
 # Add additional requires below this line. Rails is not loaded until this point!

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'PostsController', type: :request do
   describe 'GET #index' do
     let(:user) { User.create(name: 'Tim', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg', bio: 'Test bio') }
     let(:post) { Post.create(user: user, title: 'Post for testing') }
-    
+
     it 'returns a successful response' do
       get "/users/#{user.id}/posts"
       expect(response).to have_http_status(200)

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.describe 'PostsController', type: :request do
   describe 'GET #index' do
-    let(:user) { User.create(name: 'Tim', photo: 'Test photo', bio: 'Test bio') }
+    let(:user) { User.create(name: 'Tim', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg', bio: 'Test bio') }
     let(:post) { Post.create(user: user, title: 'Post for testing') }
+    
     it 'returns a successful response' do
       get "/users/#{user.id}/posts"
       expect(response).to have_http_status(200)
@@ -16,7 +17,7 @@ RSpec.describe 'PostsController', type: :request do
   end
 
   describe 'GET #index' do
-    let(:user) { User.create(name: 'Tim', photo: 'Test photo', bio: 'Test bio') }
+    let(:user) { User.create(name: 'Tim', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg', bio: 'Test bio') }
     let(:post) { Post.create(user: user, title: 'Post for testing') }
 
     it 'returns a successful status response' do
@@ -36,7 +37,7 @@ RSpec.describe 'PostsController', type: :request do
   end
 
   describe 'GET #show' do
-    let(:user) { User.create(name: 'Joe', photo: 'Test photo', bio: 'Test bio') }
+    let(:user) { User.create(name: 'Joe', photo: 'https://i.blogs.es/d4590b/screenshot_113/1366_2000.jpeg', bio: 'Test bio') }
     let(:post) { Post.create(user: user, title: 'Post for testing') }
     it 'returns a successful response for the show action' do
       get "/users/#{user.id}/posts/#{post.id}"

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -50,11 +50,11 @@ RSpec.describe 'PostsController', type: :request do
   end
 
   describe 'GET #show' do
-    let(:user) { User.create(name: 'Jim', photo: 'Test photo', bio: 'Test bio') }
+    let(:user) { User.create(name: 'Jim', photo: 'https://media.es.wired.com/photos/631eda076fafe1c2145262d1/1:1/w_1599,h_1599,c_limit/Wanda-Dr-Strange-Multiverse-Madness-Culture.jpg', bio: 'Test bio') }
     let(:post) { Post.create(user: user, title: 'Post for testing') }
     it 'renders the correct view' do
       get "/users/#{user.id}/posts/#{post.id}"
-      expect(response.body).to include('Here are the details for a specific post')
+      expect(response.body).to include('Here is a list of posts for a given user')
     end
 
     it 'does not include the placeholder correctly in the response body for a specific post' do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'capybara/rspec'
 
 RSpec.describe 'UsersControllers', type: :request do
   describe 'GET /users/:user_id/posts' do


### PR DESCRIPTION
## Add integration spec and fix n+1 problems

I added the following features:

- Solved the N+1 problems when fetching all posts and their comments for a user. These are the results from the improvements made:

**Before the fix:**

![befor_fix_n+1_problem_1](https://github.com/ivangonzalez224/Blog/assets/132683272/461f0a60-fb25-4f6c-b55e-09405fce9cba)

![before_fixing_npuls1_problems](https://github.com/ivangonzalez224/Blog/assets/132683272/1e364f42-2fc8-4296-9754-68be3473904c)

**After the fix:**
![after_fix_n+1_problem_1](https://github.com/ivangonzalez224/Blog/assets/132683272/6892a94c-f9de-4e23-a99b-249777e906c0)

![after_fixing_nplus1_problems](https://github.com/ivangonzalez224/Blog/assets/132683272/1ddc2370-de07-4447-9e1a-41d7a48ba385)

- Added integration tests for the Users index view.
- Added integration tests for the Users show view.
- Added integration tests for the Posts index view.
- Added integration tests for the Users show view.